### PR TITLE
#52 <Feat>: Добавить пересылку сообщений

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/deep-assistant/GPTutor/issues/52
+Your prepared branch: issue-52-8d0799e3
+Your prepared working directory: /tmp/gh-issue-solver-1757528399528
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/deep-assistant/GPTutor/issues/52
-Your prepared branch: issue-52-8d0799e3
-Your prepared working directory: /tmp/gh-issue-solver-1757528399528
-
-Proceed.

--- a/GPTutor-Frontend/src/components/Messenger/MessengerList/Message/Message.tsx
+++ b/GPTutor-Frontend/src/components/Messenger/MessengerList/Message/Message.tsx
@@ -8,7 +8,7 @@ import {
   Text,
   Title,
 } from "@vkontakte/vkui";
-import { Icon24CheckCircleOutline } from "@vkontakte/icons";
+import { Icon24CheckCircleOutline, Icon24Share } from "@vkontakte/icons";
 
 import { GptMessage } from "$/entity/GPT";
 
@@ -23,6 +23,7 @@ import classes from "./Message.module.css";
 import { Copy } from "$/components/Copy";
 import { ChatGptTemplate } from "$/entity/GPT/ChatGptTemplate";
 import { appService } from "$/services/AppService";
+import { shareService } from "$/services/ShareService";
 
 interface IProps {
   chatGpt: ChatGptTemplate;
@@ -43,6 +44,15 @@ function Message({ chatGpt, message }: IProps) {
   const onSelectFirstMessage = (e: any) => {
     e.stopPropagation();
     message.toggleSelected();
+  };
+
+  const onForwardMessage = (e: any) => {
+    e.stopPropagation();
+    const senderName = message.role === "assistant" 
+      ? appService.getGPTName() 
+      : vkUser?.first_name || "Пользователь";
+    
+    shareService.forwardMessage(message.content$.get(), senderName);
   };
 
   return (
@@ -69,6 +79,9 @@ function Message({ chatGpt, message }: IProps) {
                 <WarningTooltip />
               )}
               <Copy textToClickBoard={message.content$.get()} />
+              <IconButton onClick={onForwardMessage}>
+                <Icon24Share />
+              </IconButton>
               <IconButton
                 className={selected ? classes.selectedIcon : ""}
                 onClick={onSelectFirstMessage}

--- a/GPTutor-Frontend/src/services/ShareService.ts
+++ b/GPTutor-Frontend/src/services/ShareService.ts
@@ -14,6 +14,23 @@ class ShareService {
         console.log(data);
       });
   }
+
+  forwardMessage(messageContent: string, senderName: string) {
+    const forwardText = `Сообщение от ${senderName}:\n\n${messageContent}\n\nПередано через GPTutor: https://vk.com/app51602327`;
+    
+    return bridge
+      .send("VKWebAppShowWallPostBox", {
+        message: forwardText,
+      })
+      .then((data) => {
+        console.log("Message forwarded successfully:", data);
+        return data;
+      })
+      .catch((error) => {
+        console.error("Error forwarding message:", error);
+        throw error;
+      });
+  }
 }
 
 export const shareService = new ShareService();

--- a/examples/test-forward-functionality.md
+++ b/examples/test-forward-functionality.md
@@ -1,0 +1,45 @@
+# Testing Message Forwarding Functionality
+
+## Changes Made
+
+1. **ShareService.ts** - Added `forwardMessage` method
+   - Takes message content and sender name
+   - Creates formatted message with source attribution
+   - Uses VK Bridge to show wall post box
+   - Returns promise for proper error handling
+
+2. **Message.tsx** - Added forward button
+   - Added `Icon24Share` import from VK icons
+   - Added `shareService` import
+   - Created `onForwardMessage` handler
+   - Added IconButton with share icon in the icons block
+
+## Expected Behavior
+
+When user clicks the forward (share) icon on any message:
+1. The `onForwardMessage` handler is triggered
+2. It extracts the sender name (GPT name for assistant or user's first name)
+3. Creates formatted forwarding text including:
+   - Original sender identification
+   - Complete message content
+   - Attribution to GPTutor app
+4. Opens VK wall post box with the formatted message
+5. User can share to their wall or send to friends
+
+## Integration Points
+
+- Uses existing VK Bridge integration
+- Follows existing UI patterns (same icon styling as copy/select buttons)
+- Maintains existing message structure and styling
+- Compatible with existing message selection system
+
+## Files Modified
+
+- `/src/services/ShareService.ts` - Added forwardMessage method
+- `/src/components/Messenger/MessengerList/Message/Message.tsx` - Added forward button and handler
+
+## Russian Context
+
+The forwarding message is formatted in Russian:
+- "Сообщение от [Sender Name]:" - "Message from [Sender Name]:"
+- "Передано через GPTutor:" - "Forwarded via GPTutor:"


### PR DESCRIPTION
## Summary
- Добавлена возможность пересылки сообщений из чата GPTutor 
- Реализована интеграция с VK API для публикации на стене
- Добавлена кнопка пересылки в интерфейс каждого сообщения

## Changes Made
- **ShareService.ts**: Добавлен метод `forwardMessage` для пересылки сообщений через VK Bridge
- **Message.tsx**: Добавлена кнопка пересылки с иконкой share и соответствующий обработчик

## Features
- Пересылка работает как для сообщений от GPT, так и от пользователя
- Автоматическое форматирование с указанием отправителя и источника
- Интеграция с существующим UI и стилями
- Использование стандартного VK Bridge API для публикации

## Test Plan
- [x] Добавлена кнопка пересылки в каждое сообщение рядом с кнопками копирования и выбора
- [x] Обработчик клика корректно извлекает содержимое сообщения и имя отправителя
- [x] Форматирование пересылаемого текста включает атрибуцию и ссылку на приложение
- [x] Использование VKWebAppShowWallPostBox для отображения окна публикации
- [x] Поддержка как русских, так и английских имен пользователей

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #52